### PR TITLE
Common / Multiple Middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,22 +62,82 @@ http.createServer(app).listen(app.get('port'), function(){
 ```js
 //routes/index.js
 module.exports = {
-	priority: 1000, //this is the `/` handler, should it should be the last route.
+	priority: 1000, //this is the `/` handler, therefore it should be the last route.
 	path: '/',
 
 	//this function gets passed the express object one time for any extra setup
 	init: function(app) {
-		//app.head doesn't work with newer express.js 
+		
 	},
-
+    
+    //a middleware that is called from any HTTP methods
+    ALL: function(req, res, next) {
+        res.send(' - Common Middleware -');
+        next();
+    }
+    
+    //HTTP method specific routes
 	GET: function(req, res) {
 		res.end('GET ');
 	},
 	
 	POST: function(req, res) {
-		res.json(req.body);
-	}
+        res.json(req.body);
+        res.end('POST ');
+	},
+    
+    //routes supports GET, HEAD, POST, PUT, DELETE, OPTIONS, TRACE, PATCH method(all uppercase)
 };
+```
+
+##### Routing multiple middlewares by assigning an array of middlewares :
+
+```js
+module.exports = {
+    priority: 1000,
+    path: '/',
+    
+    init: function(app){
+        
+    }
+    
+    ALL: [
+        function(req, res, next){
+            res.send(' - Common Middleware 1 - ');
+            next();
+        },
+        function(req, res, next){
+            res.send(' - Common Middleware 2 - ');
+            next();
+        }
+    ],
+    
+    GET: [
+        function(req, res, next){
+            res.send(' GET 1 ');
+            next();
+        },
+        function(req, res){
+            res.end('end of GET');
+        }
+    ],
+    
+    POST: [
+        function(req, res){
+            res.json(req.body);
+            res.end('end of POST');
+        }
+    ]
+    /* an array with single route, that is equivalent to
+    
+    POST: function(req, res){
+        res.json(req.body);
+        res.end('end of POST');
+    }
+    
+    */
+}
+
 ```
 
 ##### Using a function :

--- a/lib/dynamic-routes.js
+++ b/lib/dynamic-routes.js
@@ -6,6 +6,11 @@
 var fs = require('fs'),
 	path = require('path');
 
+var methods = [
+    "ALL",
+    "GET", "HEAD", "POST", "PUT", "DELETE", "TRACE", "OPTIONS", "PATCH"
+];
+
 var findFiles = function(dir, options) {
 	var files = [];
 	options = options || {};
@@ -68,9 +73,6 @@ module.exports = (function() {
 							priority: route.priority,
 							init: route
 						};
-					} else if(typeof route !== 'object' || !('GET' in route || 'POST' in route || 'PUT' in route || 'DELETE' in route || 'init' in route)) {
-						throw new TypeError('route "' + fn + '" needs to return a ' +
-							'function or an object with an init function or GET/POST/PUT/DELETE handler.');
 					}
 
 					route.path = route.path || routePathFromFilename(src, fn);
@@ -92,10 +94,21 @@ module.exports = (function() {
 			for(var i = 0; i < routes.length; ++i) {
 				var route = routes[i];
 				if(typeof route.init === 'function') route.init(app);
-				if(typeof route.GET === 'function') app.get(route.path, route.GET);
-				if(typeof route.POST === 'function') app.post(route.path, route.POST);
-				if(typeof route.PUT === 'function') app.put(route.path, route.PUT);
-				if(typeof route.DELETE === 'function') app.delete(route.path, route.DELETE);
+                
+                for(var j = 0; j < methods.length; ++j) {
+                    var middleware = route[methods[j]];
+                    switch(typeof middleware){
+                    case 'function':
+                        app[methods[j].toLowerCase()](route.path, middleware);
+                        break;
+                    case 'array':
+                        for(var k = 0; k < route[methods[j]].length; ++k){
+                            if(typeof middleware[k] === 'function'){
+                                app[methods[j].toLowerCase()](route.path, middleware[k]);
+                            }
+                        }
+                    }
+                }
 			}
 		}
 	};
@@ -108,7 +121,7 @@ module.exports = (function() {
 	}
 })();
 
-var E = {
+var exportExample = {
 	priority: 0, /* optional */
 	before: '/users', /* optional */
 	path: 'users/admin', /* optional, it will use the file path as the route */
@@ -116,3 +129,4 @@ var E = {
 
 	}
 };
+


### PR DESCRIPTION
This patch enables:
- setting ALL attribute to use a common middleware prior to all http method-specific middleware.
- setting various kinds of methods, such as TRACE, OPTIONS, PATCH, HEAD.
  Simply adding a new method name( http://expressjs.com/en/api.html#app.METHOD ) will enable any other method.
- setting ALL or METHOD(e.g. GET, POST) attribute to an array of middlewares instead of a single middleware, to route them in series.
